### PR TITLE
Fix formatting using `go fmt`

### DIFF
--- a/goInfo.go
+++ b/goInfo.go
@@ -5,25 +5,25 @@ import (
 )
 
 type GoInfoObject struct {
-	GoOS string
-	Kernel string
-	Core string
+	GoOS     string
+	Kernel   string
+	Core     string
 	Platform string
-	OS string
+	OS       string
 	Hostname string
-	CPUs int
+	CPUs     int
 }
 
 func (gi *GoInfoObject) VarDump() {
-	fmt.Println("GoOS:",gi.GoOS)
-	fmt.Println("Kernel:",gi.Kernel)
-	fmt.Println("Core:",gi.Core)
-	fmt.Println("Platform:",gi.Platform)
-	fmt.Println("OS:",gi.OS)
-	fmt.Println("Hostname:",gi.Hostname)
-	fmt.Println("CPUs:",gi.CPUs)
+	fmt.Println("GoOS:", gi.GoOS)
+	fmt.Println("Kernel:", gi.Kernel)
+	fmt.Println("Core:", gi.Core)
+	fmt.Println("Platform:", gi.Platform)
+	fmt.Println("OS:", gi.OS)
+	fmt.Println("Hostname:", gi.Hostname)
+	fmt.Println("CPUs:", gi.CPUs)
 }
 
 func (gi *GoInfoObject) String() string {
-	return fmt.Sprintf("GoOS:%v,Kernel:%v,Core:%v,Platform:%v,OS:%v,Hostname:%v,CPUs:%v",gi.GoOS,gi.Kernel,gi.Core,gi.Platform,gi.OS,gi.Hostname,gi.CPUs)
+	return fmt.Sprintf("GoOS:%v,Kernel:%v,Core:%v,Platform:%v,OS:%v,Hostname:%v,CPUs:%v", gi.GoOS, gi.Kernel, gi.Core, gi.Platform, gi.OS, gi.Hostname, gi.CPUs)
 }

--- a/goInfo_darwin.go
+++ b/goInfo_darwin.go
@@ -1,39 +1,39 @@
 package goInfo
 
-import (		
-	"strings"	
-	"os/exec"
-	"os"
+import (
 	"bytes"
-	"runtime"
 	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
 	"time"
 )
 
-func GetInfo() *GoInfoObject {			
+func GetInfo() *GoInfoObject {
 	out := _getInfo()
-	for strings.Index(out,"broken pipe") != -1 {
+	for strings.Index(out, "broken pipe") != -1 {
 		out = _getInfo()
 		time.Sleep(500 * time.Millisecond)
 	}
-	osStr := strings.Replace(out,"\n","",-1)
-	osStr = strings.Replace(osStr,"\r\n","",-1)
-	osInfo := strings.Split(osStr," ")
-	gio := &GoInfoObject{Kernel:osInfo[0],Core:osInfo[1],Platform:osInfo[2],OS:osInfo[0],GoOS:runtime.GOOS,CPUs:runtime.NumCPU()}	
-	gio.Hostname,_ = os.Hostname()	
+	osStr := strings.Replace(out, "\n", "", -1)
+	osStr = strings.Replace(osStr, "\r\n", "", -1)
+	osInfo := strings.Split(osStr, " ")
+	gio := &GoInfoObject{Kernel: osInfo[0], Core: osInfo[1], Platform: osInfo[2], OS: osInfo[0], GoOS: runtime.GOOS, CPUs: runtime.NumCPU()}
+	gio.Hostname, _ = os.Hostname()
 	return gio
 }
 
 func _getInfo() string {
-	cmd := exec.Command("uname","-srm")
+	cmd := exec.Command("uname", "-srm")
 	cmd.Stdin = strings.NewReader("some input")
 	var out bytes.Buffer
 	var stderr bytes.Buffer
 	cmd.Stdout = &out
 	cmd.Stderr = &stderr
 	err := cmd.Run()
-	if err != nil {							
-		fmt.Println("getInfo:",err)	
+	if err != nil {
+		fmt.Println("getInfo:", err)
 	}
 	return out.String()
 }

--- a/goInfo_freebsd.go
+++ b/goInfo_freebsd.go
@@ -1,39 +1,39 @@
 package goInfo
 
-import (		
-	"strings"	
-	"os/exec"
-	"os"
+import (
 	"bytes"
-	"runtime"
 	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
 	"time"
 )
 
-func GetInfo() *GoInfoObject {			
+func GetInfo() *GoInfoObject {
 	out := _getInfo()
-	for strings.Index(out,"broken pipe") != -1 {
+	for strings.Index(out, "broken pipe") != -1 {
 		out = _getInfo()
 		time.Sleep(500 * time.Millisecond)
 	}
-	osStr := strings.Replace(out,"\n","",-1)
-	osStr = strings.Replace(osStr,"\r\n","",-1)
-	osInfo := strings.Split(osStr," ")
-	gio := &GoInfoObject{Kernel:osInfo[0],Core:osInfo[1],Platform:runtime.GOARCH,OS:osInfo[2],GoOS:runtime.GOOS,CPUs:runtime.NumCPU()}
-	gio.Hostname,_ = os.Hostname()	
+	osStr := strings.Replace(out, "\n", "", -1)
+	osStr = strings.Replace(osStr, "\r\n", "", -1)
+	osInfo := strings.Split(osStr, " ")
+	gio := &GoInfoObject{Kernel: osInfo[0], Core: osInfo[1], Platform: runtime.GOARCH, OS: osInfo[2], GoOS: runtime.GOOS, CPUs: runtime.NumCPU()}
+	gio.Hostname, _ = os.Hostname()
 	return gio
 }
 
 func _getInfo() string {
-	cmd := exec.Command("uname","-sri")
+	cmd := exec.Command("uname", "-sri")
 	cmd.Stdin = strings.NewReader("some input")
 	var out bytes.Buffer
 	var stderr bytes.Buffer
 	cmd.Stdout = &out
 	cmd.Stderr = &stderr
 	err := cmd.Run()
-	if err != nil {							
-		fmt.Println("getInfo:",err)	
+	if err != nil {
+		fmt.Println("getInfo:", err)
 	}
 	return out.String()
 }

--- a/goInfo_linux.go
+++ b/goInfo_linux.go
@@ -1,39 +1,39 @@
 package goInfo
 
-import (		
-	"strings"	
-	"os/exec"
-	"os"
+import (
 	"bytes"
-	"runtime"
 	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
 	"time"
 )
 
-func GetInfo() *GoInfoObject {			
+func GetInfo() *GoInfoObject {
 	out := _getInfo()
-	for strings.Index(out,"broken pipe") != -1 {
+	for strings.Index(out, "broken pipe") != -1 {
 		out = _getInfo()
 		time.Sleep(500 * time.Millisecond)
 	}
-	osStr := strings.Replace(out,"\n","",-1)
-	osStr = strings.Replace(osStr,"\r\n","",-1)
-	osInfo := strings.Split(osStr," ")
-	gio := &GoInfoObject{Kernel:osInfo[0],Core:osInfo[1],Platform:osInfo[2],OS:osInfo[3],GoOS:runtime.GOOS,CPUs:runtime.NumCPU()}
-	gio.Hostname,_ = os.Hostname()	
+	osStr := strings.Replace(out, "\n", "", -1)
+	osStr = strings.Replace(osStr, "\r\n", "", -1)
+	osInfo := strings.Split(osStr, " ")
+	gio := &GoInfoObject{Kernel: osInfo[0], Core: osInfo[1], Platform: osInfo[2], OS: osInfo[3], GoOS: runtime.GOOS, CPUs: runtime.NumCPU()}
+	gio.Hostname, _ = os.Hostname()
 	return gio
 }
 
 func _getInfo() string {
-	cmd := exec.Command("uname","-srio")
+	cmd := exec.Command("uname", "-srio")
 	cmd.Stdin = strings.NewReader("some input")
 	var out bytes.Buffer
 	var stderr bytes.Buffer
 	cmd.Stdout = &out
 	cmd.Stderr = &stderr
 	err := cmd.Run()
-	if err != nil {							
-		fmt.Println("getInfo:",err)	
+	if err != nil {
+		fmt.Println("getInfo:", err)
 	}
 	return out.String()
 }

--- a/goInfo_windows.go
+++ b/goInfo_windows.go
@@ -1,35 +1,35 @@
 package goInfo
 
-import (		
-	"strings"	
-	"os/exec"
-	"os"
+import (
 	"bytes"
+	"os"
+	"os/exec"
 	"runtime"
+	"strings"
 )
 
-func GetInfo() *GoInfoObject {			
-	cmd := exec.Command("cmd","ver")
-	cmd.Stdin = strings.NewReader("some input")	
+func GetInfo() *GoInfoObject {
+	cmd := exec.Command("cmd", "ver")
+	cmd.Stdin = strings.NewReader("some input")
 	var out bytes.Buffer
 	var stderr bytes.Buffer
 	cmd.Stdout = &out
 	cmd.Stderr = &stderr
 	err := cmd.Run()
-	if err != nil {							
-		panic(err)	
-	}	
-	osStr := strings.Replace(out.String(),"\n","",-1)
-	osStr = strings.Replace(osStr,"\r\n","",-1)
-	tmp1 := strings.Index(osStr,"[Version")
-	tmp2 := strings.Index(osStr,"]")
+	if err != nil {
+		panic(err)
+	}
+	osStr := strings.Replace(out.String(), "\n", "", -1)
+	osStr = strings.Replace(osStr, "\r\n", "", -1)
+	tmp1 := strings.Index(osStr, "[Version")
+	tmp2 := strings.Index(osStr, "]")
 	var ver string
 	if tmp1 == -1 || tmp2 == -1 {
 		ver = "unknown"
 	} else {
-		ver = osStr[tmp1+9:tmp2]
+		ver = osStr[tmp1+9 : tmp2]
 	}
-	gio := &GoInfoObject{Kernel:"windows",Core:ver,Platform:"unknown",OS:"windows",GoOS:runtime.GOOS,CPUs:runtime.NumCPU()}	
-	gio.Hostname,_ = os.Hostname()	
+	gio := &GoInfoObject{Kernel: "windows", Core: ver, Platform: "unknown", OS: "windows", GoOS: runtime.GOOS, CPUs: runtime.NumCPU()}
+	gio.Hostname, _ = os.Hostname()
 	return gio
 }


### PR DESCRIPTION
By running `go fmt` on the sourcetree, this ensures the entire package uses the consistent and standard go formatting.

There are no functional changes to the code at all, only formatting.