### PR TITLE
Add more information for Windows hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,7 @@ get freebsd information
 }
 ```
 
-It's will show:
-
+On Linux:
 ```sh
    GoOS: linux
    Kernel: Linux
@@ -64,6 +63,16 @@ It's will show:
    OS: GNU/Linux
    Hostname: ubuntu
    CPUs: 1
+```
+On Windows:
+```sh
+   GoOS: windows
+   Kernel: windows
+   Core: 10.0.15063 N/A Build 15063
+   Platform: x64-based PC
+   OS: Microsoft Windows 10 Pro
+   Hostname: windows10
+   CPUs: 4
 ```
 
 ##License and Copyright

--- a/goInfo_windows.go
+++ b/goInfo_windows.go
@@ -1,35 +1,52 @@
 package goInfo
 
-import (		
-	"strings"	
-	"os/exec"
-	"os"
+import (
 	"bytes"
+	"encoding/csv"
+	"os"
+	"os/exec"
 	"runtime"
 )
 
-func GetInfo() *GoInfoObject {			
-	cmd := exec.Command("cmd","ver")
-	cmd.Stdin = strings.NewReader("some input")	
+func GetInfo() *GoInfoObject {
+	// Run the systeminfo command, specifying the output to be in CSV (/FO), with no header (/NH)
+	cmd := exec.Command("systeminfo", "/NH", "/FO", "CSV")
 	var out bytes.Buffer
 	var stderr bytes.Buffer
 	cmd.Stdout = &out
 	cmd.Stderr = &stderr
 	err := cmd.Run()
-	if err != nil {							
-		panic(err)	
-	}	
-	osStr := strings.Replace(out.String(),"\n","",-1)
-	osStr = strings.Replace(osStr,"\r\n","",-1)
-	tmp1 := strings.Index(osStr,"[Version")
-	tmp2 := strings.Index(osStr,"]")
-	var ver string
-	if tmp1 == -1 || tmp2 == -1 {
-		ver = "unknown"
-	} else {
-		ver = osStr[tmp1+9:tmp2]
+	if err != nil {
+		panic(err)
 	}
-	gio := &GoInfoObject{Kernel:"windows",Core:ver,Platform:"unknown",OS:"windows",GoOS:runtime.GOOS,CPUs:runtime.NumCPU()}	
-	gio.Hostname,_ = os.Hostname()	
+	// Parse the output as a single CSV
+	r := csv.NewReader(&out)
+	records, err := r.ReadAll()
+
+	if err != nil {
+		panic(err)
+	}
+
+	// If there are less than 1 rows in the CSV, there has been some kind of mistake
+	if len(records) < 1 {
+		panic("Failed to parse the output of systeminfo as a CSV")
+	}
+
+	// TODO: We should stop cheating with the lack of CSV header and instead parse the CSV into a real map or similar so we can be sure we have the right index always
+	gio := &GoInfoObject{
+		Kernel:   "windows",        // windowss
+		Core:     records[0][2],    // 10.0.15063 N/A Build 15063
+		Platform: records[0][13],   // x64-based PC
+		OS:       records[0][1],    // Microsoft Windows 10 Pro
+		GoOS:     runtime.GOOS,     // windows
+		CPUs:     runtime.NumCPU(), // 4
+	}
+
+	// Set the hostname
+	gio.Hostname, err = os.Hostname()
+	if err != nil {
+		panic(err)
+	}
+
 	return gio
 }


### PR DESCRIPTION
This does drastically change the format of information in the struct.
As such, the README.md has been updated with a Windows example.

Internally this uses the "systeminfo" command to get much more verbose output, though is slower.