### PR TITLE
Add NetBSD and OpenBSD, return error instead of panic, and more

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/matishsiao/goInfo
+
+go 1.16

--- a/goInfo_darwin.go
+++ b/goInfo_darwin.go
@@ -2,7 +2,6 @@ package goInfo
 
 import (
 	"bytes"
-	"fmt"
 	"os"
 	"os/exec"
 	"runtime"
@@ -10,10 +9,10 @@ import (
 	"time"
 )
 
-func GetInfo() *GoInfoObject {
-	out := _getInfo()
+func GetInfo() (*GoInfoObject, error) {
+	out, err := _getInfo()
 	for strings.Index(out, "broken pipe") != -1 {
-		out = _getInfo()
+		out, err = _getInfo()
 		time.Sleep(500 * time.Millisecond)
 	}
 	osStr := strings.Replace(out, "\n", "", -1)
@@ -21,10 +20,10 @@ func GetInfo() *GoInfoObject {
 	osInfo := strings.Split(osStr, " ")
 	gio := &GoInfoObject{Kernel: osInfo[0], Core: osInfo[1], Platform: osInfo[2], OS: osInfo[0], GoOS: runtime.GOOS, CPUs: runtime.NumCPU()}
 	gio.Hostname, _ = os.Hostname()
-	return gio
+	return gio, err
 }
 
-func _getInfo() string {
+func _getInfo() (string, error) {
 	cmd := exec.Command("uname", "-srm")
 	cmd.Stdin = strings.NewReader("some input")
 	var out bytes.Buffer
@@ -32,8 +31,5 @@ func _getInfo() string {
 	cmd.Stdout = &out
 	cmd.Stderr = &stderr
 	err := cmd.Run()
-	if err != nil {
-		fmt.Println("getInfo:", err)
-	}
-	return out.String()
+	return out.String(), err
 }

--- a/goInfo_darwin.go
+++ b/goInfo_darwin.go
@@ -9,7 +9,7 @@ import (
 	"time"
 )
 
-func GetInfo() (*GoInfoObject, error) {
+func GetInfo() (GoInfoObject, error) {
 	out, err := _getInfo()
 	for strings.Index(out, "broken pipe") != -1 {
 		out, err = _getInfo()
@@ -18,7 +18,7 @@ func GetInfo() (*GoInfoObject, error) {
 	osStr := strings.Replace(out, "\n", "", -1)
 	osStr = strings.Replace(osStr, "\r\n", "", -1)
 	osInfo := strings.Split(osStr, " ")
-	gio := &GoInfoObject{Kernel: osInfo[0], Core: osInfo[1], Platform: osInfo[2], OS: osInfo[0], GoOS: runtime.GOOS, CPUs: runtime.NumCPU()}
+	gio := GoInfoObject{Kernel: osInfo[0], Core: osInfo[1], Platform: osInfo[2], OS: osInfo[0], GoOS: runtime.GOOS, CPUs: runtime.NumCPU()}
 	gio.Hostname, _ = os.Hostname()
 	return gio, err
 }

--- a/goInfo_freebsd.go
+++ b/goInfo_freebsd.go
@@ -9,7 +9,7 @@ import (
 	"time"
 )
 
-func GetInfo() (*GoInfoObject, error) {
+func GetInfo() (GoInfoObject, error) {
 	out, err := _getInfo()
 	for strings.Index(out, "broken pipe") != -1 {
 		out, err = _getInfo()
@@ -18,7 +18,7 @@ func GetInfo() (*GoInfoObject, error) {
 	osStr := strings.Replace(out, "\n", "", -1)
 	osStr = strings.Replace(osStr, "\r\n", "", -1)
 	osInfo := strings.Split(osStr, " ")
-	gio := &GoInfoObject{Kernel: osInfo[0], Core: osInfo[1], Platform: runtime.GOARCH, OS: osInfo[2], GoOS: runtime.GOOS, CPUs: runtime.NumCPU()}
+	gio := GoInfoObject{Kernel: osInfo[0], Core: osInfo[1], Platform: runtime.GOARCH, OS: osInfo[2], GoOS: runtime.GOOS, CPUs: runtime.NumCPU()}
 	gio.Hostname, _ = os.Hostname()
 	return gio, err
 }

--- a/goInfo_freebsd.go
+++ b/goInfo_freebsd.go
@@ -10,10 +10,10 @@ import (
 	"time"
 )
 
-func GetInfo() *GoInfoObject {
-	out := _getInfo()
+func GetInfo() (*GoInfoObject, error) {
+	out, err := _getInfo()
 	for strings.Index(out, "broken pipe") != -1 {
-		out = _getInfo()
+		out, err = _getInfo()
 		time.Sleep(500 * time.Millisecond)
 	}
 	osStr := strings.Replace(out, "\n", "", -1)
@@ -21,10 +21,10 @@ func GetInfo() *GoInfoObject {
 	osInfo := strings.Split(osStr, " ")
 	gio := &GoInfoObject{Kernel: osInfo[0], Core: osInfo[1], Platform: runtime.GOARCH, OS: osInfo[2], GoOS: runtime.GOOS, CPUs: runtime.NumCPU()}
 	gio.Hostname, _ = os.Hostname()
-	return gio
+	return gio, err
 }
 
-func _getInfo() string {
+func _getInfo() (string, error) {
 	cmd := exec.Command("uname", "-sri")
 	cmd.Stdin = strings.NewReader("some input")
 	var out bytes.Buffer
@@ -32,8 +32,5 @@ func _getInfo() string {
 	cmd.Stdout = &out
 	cmd.Stderr = &stderr
 	err := cmd.Run()
-	if err != nil {
-		fmt.Println("getInfo:", err)
-	}
-	return out.String()
+	return out.String(), err
 }

--- a/goInfo_freebsd.go
+++ b/goInfo_freebsd.go
@@ -2,7 +2,6 @@ package goInfo
 
 import (
 	"bytes"
-	"fmt"
 	"os"
 	"os/exec"
 	"runtime"

--- a/goInfo_linux.go
+++ b/goInfo_linux.go
@@ -10,10 +10,10 @@ import (
 	"time"
 )
 
-func GetInfo() *GoInfoObject {
-	out := _getInfo()
+func GetInfo() (*GoInfoObject, error) {
+	out, err := _getInfo()
 	for strings.Index(out, "broken pipe") != -1 {
-		out = _getInfo()
+		out, err = _getInfo()
 		time.Sleep(500 * time.Millisecond)
 	}
 	osStr := strings.Replace(out, "\n", "", -1)
@@ -21,10 +21,10 @@ func GetInfo() *GoInfoObject {
 	osInfo := strings.Split(osStr, " ")
 	gio := &GoInfoObject{Kernel: osInfo[0], Core: osInfo[1], Platform: osInfo[2], OS: osInfo[3], GoOS: runtime.GOOS, CPUs: runtime.NumCPU()}
 	gio.Hostname, _ = os.Hostname()
-	return gio
+	return gio, err
 }
 
-func _getInfo() string {
+func _getInfo() (string, error) {
 	cmd := exec.Command("uname", "-srio")
 	cmd.Stdin = strings.NewReader("some input")
 	var out bytes.Buffer
@@ -32,8 +32,5 @@ func _getInfo() string {
 	cmd.Stdout = &out
 	cmd.Stderr = &stderr
 	err := cmd.Run()
-	if err != nil {
-		fmt.Println("getInfo:", err)
-	}
-	return out.String()
+	return out.String(), err
 }

--- a/goInfo_linux.go
+++ b/goInfo_linux.go
@@ -9,7 +9,7 @@ import (
 	"time"
 )
 
-func GetInfo() (*GoInfoObject, error) {
+func GetInfo() (GoInfoObject, error) {
 	out, err := _getInfo()
 	for strings.Index(out, "broken pipe") != -1 {
 		out, err = _getInfo()
@@ -18,7 +18,7 @@ func GetInfo() (*GoInfoObject, error) {
 	osStr := strings.Replace(out, "\n", "", -1)
 	osStr = strings.Replace(osStr, "\r\n", "", -1)
 	osInfo := strings.Split(osStr, " ")
-	gio := &GoInfoObject{Kernel: osInfo[0], Core: osInfo[1], Platform: osInfo[2], OS: osInfo[3], GoOS: runtime.GOOS, CPUs: runtime.NumCPU()}
+	gio := GoInfoObject{Kernel: osInfo[0], Core: osInfo[1], Platform: osInfo[2], OS: osInfo[3], GoOS: runtime.GOOS, CPUs: runtime.NumCPU()}
 	gio.Hostname, _ = os.Hostname()
 	return gio, err
 }

--- a/goInfo_linux.go
+++ b/goInfo_linux.go
@@ -2,7 +2,6 @@ package goInfo
 
 import (
 	"bytes"
-	"fmt"
 	"os"
 	"os/exec"
 	"runtime"

--- a/goInfo_netbsd.go
+++ b/goInfo_netbsd.go
@@ -9,7 +9,7 @@ import (
 	"time"
 )
 
-func GetInfo() (*GoInfoObject, error) {
+func GetInfo() (GoInfoObject, error) {
 	out, err := _getInfo()
 	for strings.Index(out, "broken pipe") != -1 {
 		out, err = _getInfo()
@@ -18,7 +18,7 @@ func GetInfo() (*GoInfoObject, error) {
 	osStr := strings.Replace(out, "\n", "", -1)
 	osStr = strings.Replace(osStr, "\r\n", "", -1)
 	osInfo := strings.Split(osStr, " ")
-	gio := &GoInfoObject{Kernel: osInfo[0], Core: osInfo[1], Platform: runtime.GOARCH, OS: osInfo[2], GoOS: runtime.GOOS, CPUs: runtime.NumCPU()}
+	gio := GoInfoObject{Kernel: osInfo[0], Core: osInfo[1], Platform: runtime.GOARCH, OS: osInfo[2], GoOS: runtime.GOOS, CPUs: runtime.NumCPU()}
 	gio.Hostname, _ = os.Hostname()
 	return gio, err
 }

--- a/goInfo_netbsd.go
+++ b/goInfo_netbsd.go
@@ -1,0 +1,39 @@
+package goInfo
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func GetInfo() *GoInfoObject {
+	out := _getInfo()
+	for strings.Index(out, "broken pipe") != -1 {
+		out = _getInfo()
+		time.Sleep(500 * time.Millisecond)
+	}
+	osStr := strings.Replace(out, "\n", "", -1)
+	osStr = strings.Replace(osStr, "\r\n", "", -1)
+	osInfo := strings.Split(osStr, " ")
+	gio := &GoInfoObject{Kernel: osInfo[0], Core: osInfo[1], Platform: runtime.GOARCH, OS: osInfo[2], GoOS: runtime.GOOS, CPUs: runtime.NumCPU()}
+	gio.Hostname, _ = os.Hostname()
+	return gio
+}
+
+func _getInfo() string {
+	cmd := exec.Command("uname", "-srm")
+	cmd.Stdin = strings.NewReader("some input")
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		fmt.Println("getInfo:", err)
+	}
+	return out.String()
+}

--- a/goInfo_netbsd.go
+++ b/goInfo_netbsd.go
@@ -10,10 +10,10 @@ import (
 	"time"
 )
 
-func GetInfo() *GoInfoObject {
-	out := _getInfo()
+func GetInfo() (*GoInfoObject, error) {
+	out, err := _getInfo()
 	for strings.Index(out, "broken pipe") != -1 {
-		out = _getInfo()
+		out, err = _getInfo()
 		time.Sleep(500 * time.Millisecond)
 	}
 	osStr := strings.Replace(out, "\n", "", -1)
@@ -21,10 +21,10 @@ func GetInfo() *GoInfoObject {
 	osInfo := strings.Split(osStr, " ")
 	gio := &GoInfoObject{Kernel: osInfo[0], Core: osInfo[1], Platform: runtime.GOARCH, OS: osInfo[2], GoOS: runtime.GOOS, CPUs: runtime.NumCPU()}
 	gio.Hostname, _ = os.Hostname()
-	return gio
+	return gio, err
 }
 
-func _getInfo() string {
+func _getInfo() (string, error) {
 	cmd := exec.Command("uname", "-srm")
 	cmd.Stdin = strings.NewReader("some input")
 	var out bytes.Buffer
@@ -32,8 +32,5 @@ func _getInfo() string {
 	cmd.Stdout = &out
 	cmd.Stderr = &stderr
 	err := cmd.Run()
-	if err != nil {
-		fmt.Println("getInfo:", err)
-	}
-	return out.String()
+	return out.String(), err
 }

--- a/goInfo_netbsd.go
+++ b/goInfo_netbsd.go
@@ -2,7 +2,6 @@ package goInfo
 
 import (
 	"bytes"
-	"fmt"
 	"os"
 	"os/exec"
 	"runtime"

--- a/goInfo_openbsd.go
+++ b/goInfo_openbsd.go
@@ -9,7 +9,7 @@ import (
 	"time"
 )
 
-func GetInfo() (*GoInfoObject, error) {
+func GetInfo() (GoInfoObject, error) {
 	out, err := _getInfo()
 	for strings.Index(out, "broken pipe") != -1 {
 		out, err = _getInfo()
@@ -18,7 +18,7 @@ func GetInfo() (*GoInfoObject, error) {
 	osStr := strings.Replace(out, "\n", "", -1)
 	osStr = strings.Replace(osStr, "\r\n", "", -1)
 	osInfo := strings.Split(osStr, " ")
-	gio := &GoInfoObject{Kernel: osInfo[0], Core: osInfo[1], Platform: runtime.GOARCH, OS: osInfo[2], GoOS: runtime.GOOS, CPUs: runtime.NumCPU()}
+	gio := GoInfoObject{Kernel: osInfo[0], Core: osInfo[1], Platform: runtime.GOARCH, OS: osInfo[2], GoOS: runtime.GOOS, CPUs: runtime.NumCPU()}
 	gio.Hostname, _ = os.Hostname()
 	return gio, err
 }

--- a/goInfo_openbsd.go
+++ b/goInfo_openbsd.go
@@ -1,0 +1,39 @@
+package goInfo
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func GetInfo() *GoInfoObject {
+	out := _getInfo()
+	for strings.Index(out, "broken pipe") != -1 {
+		out = _getInfo()
+		time.Sleep(500 * time.Millisecond)
+	}
+	osStr := strings.Replace(out, "\n", "", -1)
+	osStr = strings.Replace(osStr, "\r\n", "", -1)
+	osInfo := strings.Split(osStr, " ")
+	gio := &GoInfoObject{Kernel: osInfo[0], Core: osInfo[1], Platform: runtime.GOARCH, OS: osInfo[2], GoOS: runtime.GOOS, CPUs: runtime.NumCPU()}
+	gio.Hostname, _ = os.Hostname()
+	return gio
+}
+
+func _getInfo() string {
+	cmd := exec.Command("uname", "-srm")
+	cmd.Stdin = strings.NewReader("some input")
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		fmt.Println("getInfo:", err)
+	}
+	return out.String()
+}

--- a/goInfo_openbsd.go
+++ b/goInfo_openbsd.go
@@ -10,10 +10,10 @@ import (
 	"time"
 )
 
-func GetInfo() *GoInfoObject {
-	out := _getInfo()
+func GetInfo() (*GoInfoObject, error) {
+	out, err := _getInfo()
 	for strings.Index(out, "broken pipe") != -1 {
-		out = _getInfo()
+		out, err = _getInfo()
 		time.Sleep(500 * time.Millisecond)
 	}
 	osStr := strings.Replace(out, "\n", "", -1)
@@ -21,10 +21,10 @@ func GetInfo() *GoInfoObject {
 	osInfo := strings.Split(osStr, " ")
 	gio := &GoInfoObject{Kernel: osInfo[0], Core: osInfo[1], Platform: runtime.GOARCH, OS: osInfo[2], GoOS: runtime.GOOS, CPUs: runtime.NumCPU()}
 	gio.Hostname, _ = os.Hostname()
-	return gio
+	return gio, err
 }
 
-func _getInfo() string {
+func _getInfo() (string, error) {
 	cmd := exec.Command("uname", "-srm")
 	cmd.Stdin = strings.NewReader("some input")
 	var out bytes.Buffer
@@ -32,8 +32,5 @@ func _getInfo() string {
 	cmd.Stdout = &out
 	cmd.Stderr = &stderr
 	err := cmd.Run()
-	if err != nil {
-		fmt.Println("getInfo:", err)
-	}
-	return out.String()
+	return out.String(), err
 }

--- a/goInfo_openbsd.go
+++ b/goInfo_openbsd.go
@@ -2,7 +2,6 @@ package goInfo
 
 import (
 	"bytes"
-	"fmt"
 	"os"
 	"os/exec"
 	"runtime"

--- a/goInfo_windows.go
+++ b/goInfo_windows.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 )
 
-func GetInfo() (*GoInfoObject, error) {
+func GetInfo() (GoInfoObject, error) {
 	cmd := exec.Command("cmd", "ver")
 	cmd.Stdin = strings.NewReader("some input")
 	var out bytes.Buffer
@@ -18,7 +18,8 @@ func GetInfo() (*GoInfoObject, error) {
 	cmd.Stderr = &stderr
 	err := cmd.Run()
 	if err != nil {
-		return nil, fmt.Errorf("getInfo: %s", err)
+		gio := GoInfoObject{Kernel: "windows", Core: "unknown", Platform: "unknown", OS: "windows", GoOS: runtime.GOOS, CPUs: runtime.NumCPU(), Hostname: os.Hostname()}
+		return gio, fmt.Errorf("getInfo: %s", err)
 	}
 	osStr := strings.Replace(out.String(), "\n", "", -1)
 	osStr = strings.Replace(osStr, "\r\n", "", -1)
@@ -30,7 +31,6 @@ func GetInfo() (*GoInfoObject, error) {
 	} else {
 		ver = osStr[tmp1+9 : tmp2]
 	}
-	gio := &GoInfoObject{Kernel: "windows", Core: ver, Platform: "unknown", OS: "windows", GoOS: runtime.GOOS, CPUs: runtime.NumCPU()}
-	gio.Hostname, _ = os.Hostname()
+	gio := GoInfoObject{Kernel: "windows", Core: ver, Platform: "unknown", OS: "windows", GoOS: runtime.GOOS, CPUs: runtime.NumCPU(), Hostname: os.Hostname()}
 	return gio, nil
 }

--- a/goInfo_windows.go
+++ b/goInfo_windows.go
@@ -18,7 +18,8 @@ func GetInfo() (GoInfoObject, error) {
 	cmd.Stderr = &stderr
 	err := cmd.Run()
 	if err != nil {
-		gio := GoInfoObject{Kernel: "windows", Core: "unknown", Platform: "unknown", OS: "windows", GoOS: runtime.GOOS, CPUs: runtime.NumCPU(), Hostname: os.Hostname()}
+		gio := GoInfoObject{Kernel: "windows", Core: "unknown", Platform: "unknown", OS: "windows", GoOS: runtime.GOOS, CPUs: runtime.NumCPU()}
+		gio.Hostname, _ = os.Hostname()
 		return gio, fmt.Errorf("getInfo: %s", err)
 	}
 	osStr := strings.Replace(out.String(), "\n", "", -1)
@@ -31,6 +32,7 @@ func GetInfo() (GoInfoObject, error) {
 	} else {
 		ver = osStr[tmp1+9 : tmp2]
 	}
-	gio := GoInfoObject{Kernel: "windows", Core: ver, Platform: "unknown", OS: "windows", GoOS: runtime.GOOS, CPUs: runtime.NumCPU(), Hostname: os.Hostname()}
+	gio := GoInfoObject{Kernel: "windows", Core: ver, Platform: "unknown", OS: "windows", GoOS: runtime.GOOS, CPUs: runtime.NumCPU()}
+	gio.Hostname, _ = os.Hostname()
 	return gio, nil
 }

--- a/goInfo_windows.go
+++ b/goInfo_windows.go
@@ -2,13 +2,14 @@ package goInfo
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"os/exec"
 	"runtime"
 	"strings"
 )
 
-func GetInfo() *GoInfoObject {
+func GetInfo() (*GoInfoObject, error) {
 	cmd := exec.Command("cmd", "ver")
 	cmd.Stdin = strings.NewReader("some input")
 	var out bytes.Buffer
@@ -17,7 +18,7 @@ func GetInfo() *GoInfoObject {
 	cmd.Stderr = &stderr
 	err := cmd.Run()
 	if err != nil {
-		panic(err)
+		return nil, fmt.Errorf("getInfo: %s", err)
 	}
 	osStr := strings.Replace(out.String(), "\n", "", -1)
 	osStr = strings.Replace(osStr, "\r\n", "", -1)
@@ -31,5 +32,5 @@ func GetInfo() *GoInfoObject {
 	}
 	gio := &GoInfoObject{Kernel: "windows", Core: ver, Platform: "unknown", OS: "windows", GoOS: runtime.GOOS, CPUs: runtime.NumCPU()}
 	gio.Hostname, _ = os.Hostname()
-	return gio
+	return gio, nil
 }


### PR DESCRIPTION
* Add NetBSD and OpenBSD support
* Return GoInfoObject struct as value for improved perf and so caller doesn't have to check for nil pointer
* Return `error` instead of calling `panic` (Fixes #11)