### PR TITLE
feat: support for storing runtime.GOARCH

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ get freebsd information
 ## Struct:
 ```go
   type GoInfoObject struct {
+	GoARCH string
 	GoOS string
 	Kernel string
 	Core string
@@ -57,6 +58,7 @@ get freebsd information
 It's will show:
 
 ```
+   GoARCH: amd64
    GoOS: linux
    Kernel: Linux
    Core: 3.13.0-27-generic

--- a/goInfo.go
+++ b/goInfo.go
@@ -5,6 +5,7 @@ import (
 )
 
 type GoInfoObject struct {
+	GoARCH   string
 	GoOS     string
 	Kernel   string
 	Core     string
@@ -15,6 +16,7 @@ type GoInfoObject struct {
 }
 
 func (gi *GoInfoObject) VarDump() {
+	fmt.Println("GoARCH:", gi.GoARCH)
 	fmt.Println("GoOS:", gi.GoOS)
 	fmt.Println("Kernel:", gi.Kernel)
 	fmt.Println("Core:", gi.Core)
@@ -25,5 +27,5 @@ func (gi *GoInfoObject) VarDump() {
 }
 
 func (gi *GoInfoObject) String() string {
-	return fmt.Sprintf("GoOS:%v,Kernel:%v,Core:%v,Platform:%v,OS:%v,Hostname:%v,CPUs:%v", gi.GoOS, gi.Kernel, gi.Core, gi.Platform, gi.OS, gi.Hostname, gi.CPUs)
+	return fmt.Sprintf("GoARCH:%s,GoOS:%v,Kernel:%v,Core:%v,Platform:%v,OS:%v,Hostname:%v,CPUs:%v", gi.GoARCH, gi.GoOS, gi.Kernel, gi.Core, gi.Platform, gi.OS, gi.Hostname, gi.CPUs)
 }

--- a/goInfo_darwin.go
+++ b/goInfo_darwin.go
@@ -18,7 +18,7 @@ func GetInfo() (GoInfoObject, error) {
 	osStr := strings.Replace(out, "\n", "", -1)
 	osStr = strings.Replace(osStr, "\r\n", "", -1)
 	osInfo := strings.Split(osStr, " ")
-	gio := GoInfoObject{Kernel: osInfo[0], Core: osInfo[1], Platform: osInfo[2], OS: osInfo[0], GoOS: runtime.GOOS, CPUs: runtime.NumCPU()}
+	gio := GoInfoObject{Kernel: osInfo[0], Core: osInfo[1], Platform: osInfo[2], OS: osInfo[0], GoARCH: runtime.GOARCH, GoOS: runtime.GOOS, CPUs: runtime.NumCPU()}
 	gio.Hostname, _ = os.Hostname()
 	return gio, err
 }

--- a/goInfo_freebsd.go
+++ b/goInfo_freebsd.go
@@ -18,7 +18,7 @@ func GetInfo() (GoInfoObject, error) {
 	osStr := strings.Replace(out, "\n", "", -1)
 	osStr = strings.Replace(osStr, "\r\n", "", -1)
 	osInfo := strings.Split(osStr, " ")
-	gio := GoInfoObject{Kernel: osInfo[0], Core: osInfo[1], Platform: runtime.GOARCH, OS: osInfo[2], GoOS: runtime.GOOS, CPUs: runtime.NumCPU()}
+	gio := GoInfoObject{Kernel: osInfo[0], Core: osInfo[1], Platform: runtime.GOARCH, OS: osInfo[2], GoARCH: runtime.GOARCH, GoOS: runtime.GOOS, CPUs: runtime.NumCPU()}
 	gio.Hostname, _ = os.Hostname()
 	return gio, err
 }

--- a/goInfo_linux.go
+++ b/goInfo_linux.go
@@ -18,7 +18,7 @@ func GetInfo() (GoInfoObject, error) {
 	osStr := strings.Replace(out, "\n", "", -1)
 	osStr = strings.Replace(osStr, "\r\n", "", -1)
 	osInfo := strings.Split(osStr, " ")
-	gio := GoInfoObject{Kernel: osInfo[0], Core: osInfo[1], Platform: osInfo[2], OS: osInfo[3], GoOS: runtime.GOOS, CPUs: runtime.NumCPU()}
+	gio := GoInfoObject{Kernel: osInfo[0], Core: osInfo[1], Platform: osInfo[2], OS: osInfo[3], GoARCH: runtime.GOARCH, GoOS: runtime.GOOS, CPUs: runtime.NumCPU()}
 	gio.Hostname, _ = os.Hostname()
 	return gio, err
 }

--- a/goInfo_netbsd.go
+++ b/goInfo_netbsd.go
@@ -18,7 +18,7 @@ func GetInfo() (GoInfoObject, error) {
 	osStr := strings.Replace(out, "\n", "", -1)
 	osStr = strings.Replace(osStr, "\r\n", "", -1)
 	osInfo := strings.Split(osStr, " ")
-	gio := GoInfoObject{Kernel: osInfo[0], Core: osInfo[1], Platform: runtime.GOARCH, OS: osInfo[2], GoOS: runtime.GOOS, CPUs: runtime.NumCPU()}
+	gio := GoInfoObject{Kernel: osInfo[0], Core: osInfo[1], Platform: runtime.GOARCH, OS: osInfo[2], GoARCH: runtime.GOARCH, GoOS: runtime.GOOS, CPUs: runtime.NumCPU()}
 	gio.Hostname, _ = os.Hostname()
 	return gio, err
 }

--- a/goInfo_openbsd.go
+++ b/goInfo_openbsd.go
@@ -18,7 +18,7 @@ func GetInfo() (GoInfoObject, error) {
 	osStr := strings.Replace(out, "\n", "", -1)
 	osStr = strings.Replace(osStr, "\r\n", "", -1)
 	osInfo := strings.Split(osStr, " ")
-	gio := GoInfoObject{Kernel: osInfo[0], Core: osInfo[1], Platform: runtime.GOARCH, OS: osInfo[2], GoOS: runtime.GOOS, CPUs: runtime.NumCPU()}
+	gio := GoInfoObject{Kernel: osInfo[0], Core: osInfo[1], Platform: runtime.GOARCH, OS: osInfo[2], GoARCH: runtime.GOARCH, GoOS: runtime.GOOS, CPUs: runtime.NumCPU()}
 	gio.Hostname, _ = os.Hostname()
 	return gio, err
 }

--- a/goInfo_windows.go
+++ b/goInfo_windows.go
@@ -18,7 +18,7 @@ func GetInfo() (GoInfoObject, error) {
 	cmd.Stderr = &stderr
 	err := cmd.Run()
 	if err != nil {
-		gio := GoInfoObject{Kernel: "windows", Core: "unknown", Platform: "unknown", OS: "windows", GoOS: runtime.GOOS, CPUs: runtime.NumCPU()}
+		gio := GoInfoObject{Kernel: "windows", Core: "unknown", Platform: "unknown", OS: "windows", GoARCH: runtime.GOARCH, GoOS: runtime.GOOS, CPUs: runtime.NumCPU()}
 		gio.Hostname, _ = os.Hostname()
 		return gio, fmt.Errorf("getInfo: %s", err)
 	}


### PR DESCRIPTION
This PR adds support for storing runtime.GOARCH into the existing struct, as it could be important to retrieve the architecture too.
