### PR TITLE
Prevent panic from index out of range

### DIFF
--- a/common.go
+++ b/common.go
@@ -1,0 +1,63 @@
+package goInfo
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func _getInfo(flags string) (string, string, string, string, error) {
+	out, err := _uname(flags)
+	tries := 0
+	for strings.Contains(out, "broken pipe") && tries < 3 {
+		out, err = _uname(flags)
+		time.Sleep(500 * time.Millisecond)
+		tries++
+	}
+	if strings.Contains(out, "broken pipe") {
+		out = ""
+	}
+	kernel, core, platform, osname := _expandInfo(out)
+	return kernel, core, platform, osname, err
+}
+
+func _uname(flags string) (string, error) {
+	cmd := exec.Command("uname", flags)
+	cmd.Stdin = strings.NewReader("some input")
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func _expandInfo(osStr string) (string, string, string, string) {
+	osStr = strings.Replace(osStr, "\n", "", -1)
+	osStr = strings.Replace(osStr, "\r\n", "", -1)
+	osInfo := strings.Split(osStr, " ")
+	kernel := "Unknown"
+	core := "Unknown"
+	platform := "Unknown"
+	osname := "Unknown"
+	if len(osInfo) > 0 {
+		kernel = osInfo[0]
+	}
+	if len(osInfo) > 1 {
+		core = osInfo[1]
+	}
+	if len(osInfo) > 2 {
+		platform = osInfo[2]
+	}
+	if len(osInfo) > 3 {
+		osname = osInfo[3]
+	}
+	return kernel, core, platform, osname
+}
+
+func _hostname() string {
+	host, _ := os.Hostname()
+	return host
+}

--- a/goInfo_darwin.go
+++ b/goInfo_darwin.go
@@ -1,35 +1,19 @@
 package goInfo
 
 import (
-	"bytes"
-	"os"
-	"os/exec"
 	"runtime"
-	"strings"
-	"time"
 )
 
 func GetInfo() (GoInfoObject, error) {
-	out, err := _getInfo()
-	for strings.Index(out, "broken pipe") != -1 {
-		out, err = _getInfo()
-		time.Sleep(500 * time.Millisecond)
+	kernel, core, platform, _, err := _getInfo("-srm")
+	gio := GoInfoObject{
+		Kernel:   kernel,
+		Core:     core,
+		Platform: platform,
+		OS:       kernel,
+		GoOS:     runtime.GOOS,
+		CPUs:     runtime.NumCPU(),
+		Hostname: _hostname(),
 	}
-	osStr := strings.Replace(out, "\n", "", -1)
-	osStr = strings.Replace(osStr, "\r\n", "", -1)
-	osInfo := strings.Split(osStr, " ")
-	gio := GoInfoObject{Kernel: osInfo[0], Core: osInfo[1], Platform: osInfo[2], OS: osInfo[0], GoOS: runtime.GOOS, CPUs: runtime.NumCPU()}
-	gio.Hostname, _ = os.Hostname()
 	return gio, err
-}
-
-func _getInfo() (string, error) {
-	cmd := exec.Command("uname", "-srm")
-	cmd.Stdin = strings.NewReader("some input")
-	var out bytes.Buffer
-	var stderr bytes.Buffer
-	cmd.Stdout = &out
-	cmd.Stderr = &stderr
-	err := cmd.Run()
-	return out.String(), err
 }

--- a/goInfo_freebsd.go
+++ b/goInfo_freebsd.go
@@ -1,35 +1,19 @@
 package goInfo
 
 import (
-	"bytes"
-	"os"
-	"os/exec"
 	"runtime"
-	"strings"
-	"time"
 )
 
 func GetInfo() (GoInfoObject, error) {
-	out, err := _getInfo()
-	for strings.Index(out, "broken pipe") != -1 {
-		out, err = _getInfo()
-		time.Sleep(500 * time.Millisecond)
+	kernel, core, platform, _, err := _getInfo("-sri")
+	gio := GoInfoObject{
+		Kernel:   kernel,
+		Core:     core,
+		Platform: runtime.GOARCH,
+		OS:       platform,
+		GoOS:     runtime.GOOS,
+		CPUs:     runtime.NumCPU(),
+		Hostname: _hostname(),
 	}
-	osStr := strings.Replace(out, "\n", "", -1)
-	osStr = strings.Replace(osStr, "\r\n", "", -1)
-	osInfo := strings.Split(osStr, " ")
-	gio := GoInfoObject{Kernel: osInfo[0], Core: osInfo[1], Platform: runtime.GOARCH, OS: osInfo[2], GoOS: runtime.GOOS, CPUs: runtime.NumCPU()}
-	gio.Hostname, _ = os.Hostname()
 	return gio, err
-}
-
-func _getInfo() (string, error) {
-	cmd := exec.Command("uname", "-sri")
-	cmd.Stdin = strings.NewReader("some input")
-	var out bytes.Buffer
-	var stderr bytes.Buffer
-	cmd.Stdout = &out
-	cmd.Stderr = &stderr
-	err := cmd.Run()
-	return out.String(), err
 }

--- a/goInfo_linux.go
+++ b/goInfo_linux.go
@@ -1,35 +1,19 @@
 package goInfo
 
 import (
-	"bytes"
-	"os"
-	"os/exec"
 	"runtime"
-	"strings"
-	"time"
 )
 
 func GetInfo() (GoInfoObject, error) {
-	out, err := _getInfo()
-	for strings.Index(out, "broken pipe") != -1 {
-		out, err = _getInfo()
-		time.Sleep(500 * time.Millisecond)
+	kernel, core, platform, osname, err := _getInfo("-srio")
+	gio := GoInfoObject{
+		Kernel:   kernel,
+		Core:     core,
+		Platform: platform,
+		OS:       osname,
+		GoOS:     runtime.GOOS,
+		CPUs:     runtime.NumCPU(),
+		Hostname: _hostname(),
 	}
-	osStr := strings.Replace(out, "\n", "", -1)
-	osStr = strings.Replace(osStr, "\r\n", "", -1)
-	osInfo := strings.Split(osStr, " ")
-	gio := GoInfoObject{Kernel: osInfo[0], Core: osInfo[1], Platform: osInfo[2], OS: osInfo[3], GoOS: runtime.GOOS, CPUs: runtime.NumCPU()}
-	gio.Hostname, _ = os.Hostname()
 	return gio, err
-}
-
-func _getInfo() (string, error) {
-	cmd := exec.Command("uname", "-srio")
-	cmd.Stdin = strings.NewReader("some input")
-	var out bytes.Buffer
-	var stderr bytes.Buffer
-	cmd.Stdout = &out
-	cmd.Stderr = &stderr
-	err := cmd.Run()
-	return out.String(), err
 }

--- a/goInfo_netbsd.go
+++ b/goInfo_netbsd.go
@@ -1,35 +1,19 @@
 package goInfo
 
 import (
-	"bytes"
-	"os"
-	"os/exec"
 	"runtime"
-	"strings"
-	"time"
 )
 
 func GetInfo() (GoInfoObject, error) {
-	out, err := _getInfo()
-	for strings.Index(out, "broken pipe") != -1 {
-		out, err = _getInfo()
-		time.Sleep(500 * time.Millisecond)
+	kernel, core, platform, _, err := _getInfo("-srm")
+	gio := GoInfoObject{
+		Kernel:   kernel,
+		Core:     core,
+		Platform: runtime.GOARCH,
+		OS:       platform,
+		GoOS:     runtime.GOOS,
+		CPUs:     runtime.NumCPU(),
+		Hostname: _hostname(),
 	}
-	osStr := strings.Replace(out, "\n", "", -1)
-	osStr = strings.Replace(osStr, "\r\n", "", -1)
-	osInfo := strings.Split(osStr, " ")
-	gio := GoInfoObject{Kernel: osInfo[0], Core: osInfo[1], Platform: runtime.GOARCH, OS: osInfo[2], GoOS: runtime.GOOS, CPUs: runtime.NumCPU()}
-	gio.Hostname, _ = os.Hostname()
 	return gio, err
-}
-
-func _getInfo() (string, error) {
-	cmd := exec.Command("uname", "-srm")
-	cmd.Stdin = strings.NewReader("some input")
-	var out bytes.Buffer
-	var stderr bytes.Buffer
-	cmd.Stdout = &out
-	cmd.Stderr = &stderr
-	err := cmd.Run()
-	return out.String(), err
 }

--- a/goInfo_openbsd.go
+++ b/goInfo_openbsd.go
@@ -1,35 +1,19 @@
 package goInfo
 
 import (
-	"bytes"
-	"os"
-	"os/exec"
 	"runtime"
-	"strings"
-	"time"
 )
 
 func GetInfo() (GoInfoObject, error) {
-	out, err := _getInfo()
-	for strings.Index(out, "broken pipe") != -1 {
-		out, err = _getInfo()
-		time.Sleep(500 * time.Millisecond)
+	kernel, core, platform, _, err := _getInfo("-srm")
+	gio := GoInfoObject{
+		Kernel:   kernel,
+		Core:     core,
+		Platform: runtime.GOARCH,
+		OS:       platform,
+		GoOS:     runtime.GOOS,
+		CPUs:     runtime.NumCPU(),
+		Hostname: _hostname(),
 	}
-	osStr := strings.Replace(out, "\n", "", -1)
-	osStr = strings.Replace(osStr, "\r\n", "", -1)
-	osInfo := strings.Split(osStr, " ")
-	gio := GoInfoObject{Kernel: osInfo[0], Core: osInfo[1], Platform: runtime.GOARCH, OS: osInfo[2], GoOS: runtime.GOOS, CPUs: runtime.NumCPU()}
-	gio.Hostname, _ = os.Hostname()
 	return gio, err
-}
-
-func _getInfo() (string, error) {
-	cmd := exec.Command("uname", "-srm")
-	cmd.Stdin = strings.NewReader("some input")
-	var out bytes.Buffer
-	var stderr bytes.Buffer
-	cmd.Stdout = &out
-	cmd.Stderr = &stderr
-	err := cmd.Run()
-	return out.String(), err
 }

--- a/goInfo_windows.go
+++ b/goInfo_windows.go
@@ -18,7 +18,7 @@ func GetInfo() (GoInfoObject, error) {
 	cmd.Stderr = &stderr
 	err := cmd.Run()
 	if err != nil {
-		gio := GoInfoObject{Kernel: "windows", Core: "unknown", Platform: "unknown", OS: "windows", GoOS: runtime.GOOS, CPUs: runtime.NumCPU()}
+		gio := GoInfoObject{Kernel: "windows", Core: "unknown", Platform: platform(), OS: "windows", GoOS: runtime.GOOS, CPUs: runtime.NumCPU()}
 		gio.Hostname, _ = os.Hostname()
 		return gio, fmt.Errorf("getInfo: %s", err)
 	}
@@ -32,7 +32,20 @@ func GetInfo() (GoInfoObject, error) {
 	} else {
 		ver = osStr[tmp1+9 : tmp2]
 	}
-	gio := GoInfoObject{Kernel: "windows", Core: ver, Platform: "unknown", OS: "windows", GoOS: runtime.GOOS, CPUs: runtime.NumCPU()}
+	gio := GoInfoObject{Kernel: "windows", Core: ver, Platform: platform(), OS: "windows", GoOS: runtime.GOOS, CPUs: runtime.NumCPU()}
 	gio.Hostname, _ = os.Hostname()
 	return gio, nil
+}
+
+func platform() string {
+	p := runtime.GOARCH
+	switch p {
+	case "386":
+		return "i386"
+	case "amd64":
+		return "x86_64"
+	default:
+		return p
+
+	}
 }


### PR DESCRIPTION
When `osStr` is empty or too short (because it's an unreliable external input from running `uname`), the `strings.Split(osStr, " ")` results in an empty list. When trying to use that list without checking it's length, you get a panic:

`panic: runtime error: index out of range [1] with length 1`

Also refactored to remove duplicate code.